### PR TITLE
Replace u8 type with unsigned char

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ int main() {
                    NULL, NULL, NULL);
 
   // process the first handshake message → e, es, s, ss
-  u8 in[500];
+  unsigned char in[500];
   size_t in_len
   bool ret = disco_ReadMessage(&hs_server, out, out_len, in, &in_len, NULL, NULL);
   if (!ret) {
@@ -41,7 +41,7 @@ int main() {
   strobe_s s_write;
   strobe_s s_read;
   size_t out_len;
-  ret = disco_WriteMessage(&hs_server, (u8 *)"second payload", 15,
+  ret = disco_WriteMessage(&hs_server, (unsigned char *)"second payload", 15,
                                        out, &out_len, &s_read, &s_write);
   if (!ret) {
     abort();
@@ -86,10 +86,10 @@ int main() {
                    NULL, &server_keypair, NULL);
 
   // write the first handshake message → e, es, s, ss
-  u8 out[500];
+  unsigned char out[500];
   size_t out_len;
   bool ret =
-      disco_WriteMessage(&hs_client, (u8*)"hey!", 5, out, &out_len, NULL, NULL);
+      disco_WriteMessage(&hs_client, (unsigned char*)"hey!", 5, out, &out_len, NULL, NULL);
   if (!ret) {
     abort();
   }
@@ -110,8 +110,8 @@ int main() {
   assert(c_write.initialized && c_read.initialized);
 
   // send a post-handshake message
-  u8 plaintext[] = "just a simple message";
-  u8* ciphertext = (u8*)malloc(sizeof(plaintext) + 16);
+  unsigned char plaintext[] = "just a simple message";
+  unsigned char* ciphertext = (unsigned char*)malloc(sizeof(plaintext) + 16);
   memcpy(ciphertext, plaintext, sizeof(plaintext));
 
   disco_EncryptInPlace(&c_write, ciphertext, sizeof(plaintext),

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ int main() {
                    NULL, NULL, NULL);
 
   // process the first handshake message → e, es, s, ss
-  u8 in[500];
+  unsigned char in[500];
   size_t in_len
   bool ret = disco_ReadMessage(&hs_server, out, out_len, in, &in_len, NULL, NULL);
   if (!ret) {
@@ -41,7 +41,7 @@ int main() {
   strobe_s s_write;
   strobe_s s_read;
   size_t out_len;
-  ret = disco_WriteMessage(&hs_server, (u8 *)"second payload", 15,
+  ret = disco_WriteMessage(&hs_server, (unsigned char *)"second payload", 15,
                                        out, &out_len, &s_read, &s_write);
   if (!ret) {
     abort();
@@ -86,10 +86,10 @@ int main() {
                    NULL, &server_keypair, NULL);
 
   // write the first handshake message → e, es, s, ss
-  u8 out[500];
+  unsigned char out[500];
   size_t out_len;
   bool ret =
-      disco_WriteMessage(&hs_client, (u8*)"hey!", 5, out, &out_len, NULL, NULL);
+      disco_WriteMessage(&hs_client, (unsigned char*)"hey!", 5, out, &out_len, NULL, NULL);
   if (!ret) {
     abort();
   }
@@ -110,8 +110,8 @@ int main() {
   assert(c_write.initialized && c_read.initialized);
 
   // send a post-handshake message
-  u8 plaintext[] = "just a simple message";
-  u8* ciphertext = (u8*)malloc(sizeof(plaintext) + 16);
+  unsigned char plaintext[] = "just a simple message";
+  unsigned char* ciphertext = (unsigned char*)malloc(sizeof(plaintext) + 16);
   memcpy(ciphertext, plaintext, sizeof(plaintext));
 
   disco_EncryptInPlace(&c_write, ciphertext, sizeof(plaintext),

--- a/lib/tweetX25519.c
+++ b/lib/tweetX25519.c
@@ -7,9 +7,9 @@
 
 typedef long long i64;
 typedef i64 gf[16];
-extern void randombytes(u8 *, u64);
+extern void randombytes(unsigned char *, unsigned long long);
 
-static const u8 _9[32] = {9};
+static const unsigned char _9[32] = {9};
 static const gf _121665 = {0xDB41, 1};
 sv car25519(gf o) {
   int i;
@@ -31,7 +31,7 @@ sv sel25519(gf p, gf q, int b) {
   }
 }
 
-sv pack25519(u8 *o, const gf n) {
+sv pack25519(unsigned char *o, const gf n) {
   int i, j, b;
   gf m, t;
   FOR(i, 16) t[i] = n[i];
@@ -55,7 +55,7 @@ sv pack25519(u8 *o, const gf n) {
   }
 }
 
-sv unpack25519(gf o, const u8 *n) {
+sv unpack25519(gf o, const unsigned char *n) {
   int i;
   FOR(i, 16) o[i] = n[2 * i] + ((i64)n[2 * i + 1] << 8);
   o[15] &= 0x7fff;
@@ -94,8 +94,8 @@ sv inv25519(gf o, const gf i) {
   FOR(a, 16) o[a] = c[a];
 }
 
-int crypto_scalarmult(u8 *q, const u8 *n, const u8 *p) {
-  u8 z[32];
+int crypto_scalarmult(unsigned char *q, const unsigned char *n, const unsigned char *p) {
+  unsigned char z[32];
   i64 x[80], r, i;
   gf a, b, c, d, e, f;
   FOR(i, 31) z[i] = n[i];
@@ -144,11 +144,11 @@ int crypto_scalarmult(u8 *q, const u8 *n, const u8 *p) {
   return 0;
 }
 
-int crypto_scalarmult_base(u8 *q, const u8 *n) {
+int crypto_scalarmult_base(unsigned char *q, const unsigned char *n) {
   return crypto_scalarmult(q, n, _9);
 }
 
-int crypto_box_keypair(u8 *y, u8 *x) {
+int crypto_box_keypair(unsigned char *y, unsigned char *x) {
   randombytes(x, 32);
   return crypto_scalarmult_base(y, x);
 }

--- a/lib/tweetX25519.h
+++ b/lib/tweetX25519.h
@@ -1,10 +1,7 @@
 #ifndef __CURVE25519_H__
 #define __CURVE25519_H__
 
-typedef unsigned char u8;
-typedef unsigned long long u64;
-
-int crypto_scalarmult(u8 *q, const u8 *n, const u8 *p);
-int crypto_box_keypair(u8 *y, u8 *x);
+int crypto_scalarmult(unsigned char *q, const unsigned char *n, const unsigned char *p);
+int crypto_box_keypair(unsigned char *y, unsigned char *x);
 
 #endif /* __CURVE25519_H__ */


### PR DESCRIPTION
I wanted to use the example code and I was forced to include the tweetX25519.h file that contains the type definition of u8. My guess is that u8 was defined to shorten the script and fit it into multiple tweats.