### PR TITLE
RISC-V: fixes

### DIFF
--- a/lib/disco_asymmetric.h
+++ b/lib/disco_asymmetric.h
@@ -82,7 +82,7 @@ typedef struct handshakeState_ {
 // ==========
 
 // used to generate long-term key pairs for a peer
-inline void disco_generateKeyPair(keyPair *kp) {
+static inline void disco_generateKeyPair(keyPair *kp) {
   crypto_box_keypair(kp->pub, kp->priv);
   kp->isSet = true;  // TODO: is this useful? If it is, should we use a magic
                      // number here in case it's not initialized to false?

--- a/lib/tweetstrobe.c
+++ b/lib/tweetstrobe.c
@@ -215,7 +215,7 @@ inline void strobe_clone(const strobe_s *src, strobe_s *dst) {
 */
 
 void strobe_print(const strobe_s *strobe) {
-  for (int i = 0; i < sizeof(strobe->state); i++) {
+  for (size_t i = 0; i < sizeof(strobe->state); i++) {
     printf("%02x", strobe->state.b[i]);
   }
   printf("\n");

--- a/tests/test_disco.c
+++ b/tests/test_disco.c
@@ -98,7 +98,7 @@ void test_NX() {
 
   // debug
   printf("sent %zu bytes\n", out_len);
-  for (int i = 0; i < out_len; i++) {
+  for (size_t i = 0; i < out_len; i++) {
     printf("%02x", out[i]);
   }
   printf("\n");
@@ -134,7 +134,7 @@ void test_NX() {
 
   // debug
   printf("sent %zu bytes:\n", out_len);
-  for (int i = 0; i < out_len; i++) {
+  for (size_t i = 0; i < out_len; i++) {
     printf("%02x", out[i]);
   }
   printf("\n");
@@ -215,7 +215,7 @@ void test_IK() {
 
   // debug
   printf("sent %zu bytes\n", out_len);
-  for (int i = 0; i < out_len; i++) {
+  for (size_t i = 0; i < out_len; i++) {
     printf("%02x", out[i]);
   }
   printf("\n");
@@ -251,7 +251,7 @@ void test_IK() {
 
   // debug
   printf("sent %zu bytes:\n", out_len);
-  for (int i = 0; i < out_len; i++) {
+  for (size_t i = 0; i < out_len; i++) {
     printf("%02x", out[i]);
   }
   printf("\n");


### PR DESCRIPTION
Two small commits to enable RISC-V builds
* ``disco_generateKeyPair`` can't be declared ``inline`` as compiler may decide not to inline it (see C99 6.7.4 for complicated explanation ). I was getting following errors when compiling for RISC-V/32
```
/usr/local/lib/gcc/riscv64-unknown-elf/8.2.0/../../../../riscv64-unknown-elf/bin/ld: bin/tests/test_disco.o: in function `test_N':
test_disco.c:(.text+0x2e): undefined reference to `disco_generateKeyPair'
/usr/local/lib/gcc/riscv64-unknown-elf/8.2.0/../../../../riscv64-unknown-elf/bin/ld: test_disco.c:(.text+0x20c): undefined reference to `disco_generateKeyPair'
/usr/local/lib/gcc/riscv64-unknown-elf/8.2.0/../../../../riscv64-unknown-elf/bin/ld: bin/tests/test_disco.o: in function `.L0 ':
test_disco.c:(.text+0x554): undefined reference to `disco_generateKeyPair'
/usr/local/lib/gcc/riscv64-unknown-elf/8.2.0/../../../../riscv64-unknown-elf/bin/ld: test_disco.c:(.text+0x56c): undefined reference to `disco_generateKeyPair'
/usr/local/lib/gcc/riscv64-unknown-elf/8.2.0/../../../../riscv64-unknown-elf/bin/ld: bin/src/disco_asymmetric.o: in function `.L97':
disco_asymmetric.c:(.text+0x53a): undefined reference to `disco_generateKeyPair'
```

* As signed values are compared to unsigned values compiler may produce warnings, which fails a build if compiling with ``-Wextra -pedantic``